### PR TITLE
Update rbenv-bundle-exec

### DIFF
--- a/etc/rbenv.d/exec/bundle-exec.bash
+++ b/etc/rbenv.d/exec/bundle-exec.bash
@@ -1,65 +1,100 @@
 # rbenv-bundle-exec
-# Automatically runs ruby gem executables through `bundle exec` inside projects.
+# rbenv exec hook: automatically runs gem executables through `bundle exec`
+# when invoked from inside a Bundler project.
+#
+# Escape hatches:
+#   NO_BUNDLE_EXEC=1 sidekiq
+#   echo sidekiq >> ~/.no_bundle_exec
 
-[[ -n "$NO_BUNDLE_EXEC" ]] && return
-[[ "$RBENV_COMMAND" == "bundle" || "$RBENV_COMMAND" == "gem" ]] && return
+_rbe_cleanup() {
+  unset _rbe_command
+  unset _rbe_skip_file _rbe_skip_command
+  unset _rbe_pwd _rbe_dir _rbe_parent _rbe_depth _rbe_gemfile
+  unset -f _rbe_cleanup
+}
 
-command -v bundle > /dev/null 2>&1 || return
+_rbe_command="${RBENV_COMMAND-}"
 
-if [[ -f "$HOME/.no_bundle_exec" ]]; then
-  while IFS= read -r skip_cmd || [[ -n "$skip_cmd" ]]; do
-    [[ -z "$skip_cmd" || "$skip_cmd" == \#* ]] && continue
-    [[ "$RBENV_COMMAND" == "$skip_cmd" ]] && return
-  done < "$HOME/.no_bundle_exec"
+if [[ -z "$_rbe_command" ]]; then
+  _rbe_cleanup
+  return 0
 fi
 
-if [[ -z "$BUNDLE_GEMFILE" ]]; then
-  cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/rbenv-bundle-exec"
-  cache_key="${PWD//\//%2F}"
-  cache_file="$cache_dir/$cache_key"
+case "$_rbe_command" in
+  bundle|gem|ruby|irb|erb|ri|rdoc)
+    _rbe_cleanup
+    return 0
+    ;;
+esac
 
-  if [[ -f "$PWD/Gemfile" ]]; then
-    BUNDLE_GEMFILE="$PWD/Gemfile"
-  elif [[ -f "$cache_file" ]]; then
-    IFS= read -r cached_gemfile < "$cache_file"
-
-    if [[ "$cached_gemfile" == "__none__" ]]; then
-      return
-    elif [[ -f "$cached_gemfile" ]]; then
-      BUNDLE_GEMFILE="$cached_gemfile"
-    fi
-  fi
-
-  if [[ -z "$BUNDLE_GEMFILE" ]]; then
-    dir="$PWD"
-    depth=0
-
-    while [[ -n "$dir" && $depth -lt 10 ]]; do
-      if [[ -f "$dir/Gemfile" ]]; then
-        BUNDLE_GEMFILE="$dir/Gemfile"
-        break
-      fi
-
-      [[ "$dir" == "/" ]] && break
-      dir="${dir%/*}"
-      (( depth++ ))
-    done
-
-    mkdir -p "$cache_dir" 2> /dev/null
-
-    if [[ -n "$BUNDLE_GEMFILE" ]]; then
-      printf '%s\n' "$BUNDLE_GEMFILE" > "$cache_file"
-    else
-      printf '%s\n' "__none__" > "$cache_file"
-      return
-    fi
-  fi
-
-  export BUNDLE_GEMFILE
+if [[ -n "${NO_BUNDLE_EXEC-}" ]]; then
+  _rbe_cleanup
+  return 0
 fi
 
-[[ -n "$DEBUG_RBENV_BUNDLE_EXEC" ]] && echo "bundle exec ${*}" >&2
+_rbe_skip_file="${HOME-}/.no_bundle_exec"
+if [[ -n "${HOME-}" && -f "$_rbe_skip_file" ]]; then
+  while IFS= read -r _rbe_skip_command || [[ -n "$_rbe_skip_command" ]]; do
+    case "$_rbe_skip_command" in
+      ""|\#*) continue ;;
+    esac
+
+    if [[ "$_rbe_command" == "$_rbe_skip_command" ]]; then
+      _rbe_cleanup
+      return 0
+    fi
+  done < "$_rbe_skip_file"
+fi
+
+if ! command -v bundle > /dev/null 2>&1; then
+  _rbe_cleanup
+  return 0
+fi
+
+# If the caller explicitly supplied a valid bundle, honor it.
+# If it is stale, ignore it and find the nearest Gemfile normally.
+if [[ -n "${BUNDLE_GEMFILE-}" && -f "$BUNDLE_GEMFILE" ]]; then
+  _rbe_gemfile="$BUNDLE_GEMFILE"
+else
+  unset BUNDLE_GEMFILE
+
+  _rbe_pwd="${PWD-}"
+  if [[ -z "$_rbe_pwd" ]]; then
+    _rbe_cleanup
+    return 0
+  fi
+
+  _rbe_dir="$_rbe_pwd"
+  _rbe_depth=0
+  _rbe_gemfile=""
+
+  while [[ -n "$_rbe_dir" && "$_rbe_depth" -lt 20 ]]; do
+    if [[ -f "$_rbe_dir/Gemfile" ]]; then
+      _rbe_gemfile="$_rbe_dir/Gemfile"
+      break
+    fi
+
+    [[ "$_rbe_dir" == "/" ]] && break
+
+    _rbe_parent="${_rbe_dir%/*}"
+    [[ "$_rbe_parent" == "$_rbe_dir" ]] && break
+
+    _rbe_dir="$_rbe_parent"
+    _rbe_depth=$(( _rbe_depth + 1 ))
+  done
+fi
+
+if [[ -z "$_rbe_gemfile" ]]; then
+  _rbe_cleanup
+  return 0
+fi
+
+export BUNDLE_GEMFILE="$_rbe_gemfile"
+
+[[ -n "${DEBUG_RBENV_BUNDLE_EXEC-}" ]] && echo "bundle exec ${*}" >&2
 
 RBENV_COMMAND="bundle"
 RBENV_COMMAND_PATH="bundle"
-set -- "bundle" "exec" "${@}"
+set -- "bundle" "exec" "$@"
+
+_rbe_cleanup

--- a/etc/rbenv.d/exec/bundle-exec.bash
+++ b/etc/rbenv.d/exec/bundle-exec.bash
@@ -1,95 +1,53 @@
 # rbenv-bundle-exec
-# rbenv exec hook: automatically runs gem executables through `bundle exec`
-# when invoked from inside a Bundler project.
-#
-# Escape hatches:
-#   NO_BUNDLE_EXEC=1 sidekiq
-#   echo sidekiq >> ~/.no_bundle_exec
+# rbenv exec hook: run project gem executables through `bundle exec`.
 
-_rbe_cleanup() {
-  unset _rbe_command
-  unset _rbe_skip_file _rbe_skip_command
-  unset _rbe_pwd _rbe_dir _rbe_parent _rbe_depth _rbe_gemfile
-  unset -f _rbe_cleanup
-}
+command_name="${RBENV_COMMAND-}"
 
-_rbe_command="${RBENV_COMMAND-}"
-
-if [[ -z "$_rbe_command" ]]; then
-  _rbe_cleanup
-  return 0
-fi
-
-case "$_rbe_command" in
-  bundle|gem|ruby|irb|erb|ri|rdoc)
-    _rbe_cleanup
+case "$command_name" in
+  ""|bundle|gem|ruby|irb|erb|ri|rdoc)
     return 0
     ;;
 esac
 
-if [[ -n "${NO_BUNDLE_EXEC-}" ]]; then
-  _rbe_cleanup
-  return 0
-fi
+[[ -n "${NO_BUNDLE_EXEC-}" ]] && return 0
 
-_rbe_skip_file="${HOME-}/.no_bundle_exec"
-if [[ -n "${HOME-}" && -f "$_rbe_skip_file" ]]; then
-  while IFS= read -r _rbe_skip_command || [[ -n "$_rbe_skip_command" ]]; do
-    case "$_rbe_skip_command" in
+skip_file="${HOME-}/.no_bundle_exec"
+if [[ -n "${HOME-}" && -f "$skip_file" ]]; then
+  while IFS= read -r skipped_command || [[ -n "$skipped_command" ]]; do
+    case "$skipped_command" in
       ""|\#*) continue ;;
+      "$command_name") return 0 ;;
     esac
-
-    if [[ "$_rbe_command" == "$_rbe_skip_command" ]]; then
-      _rbe_cleanup
-      return 0
-    fi
-  done < "$_rbe_skip_file"
+  done < "$skip_file"
 fi
 
-if ! command -v bundle > /dev/null 2>&1; then
-  _rbe_cleanup
-  return 0
-fi
+command -v bundle > /dev/null 2>&1 || return 0
 
-# If the caller explicitly supplied a valid bundle, honor it.
-# If it is stale, ignore it and find the nearest Gemfile normally.
-if [[ -n "${BUNDLE_GEMFILE-}" && -f "$BUNDLE_GEMFILE" ]]; then
-  _rbe_gemfile="$BUNDLE_GEMFILE"
-else
-  unset BUNDLE_GEMFILE
+gemfile="${BUNDLE_GEMFILE-}"
+if [[ -z "$gemfile" || ! -f "$gemfile" ]]; then
+  gemfile=""
+  directory="${PWD-}"
+  depth=0
 
-  _rbe_pwd="${PWD-}"
-  if [[ -z "$_rbe_pwd" ]]; then
-    _rbe_cleanup
-    return 0
-  fi
-
-  _rbe_dir="$_rbe_pwd"
-  _rbe_depth=0
-  _rbe_gemfile=""
-
-  while [[ -n "$_rbe_dir" && "$_rbe_depth" -lt 20 ]]; do
-    if [[ -f "$_rbe_dir/Gemfile" ]]; then
-      _rbe_gemfile="$_rbe_dir/Gemfile"
+  while [[ -n "$directory" && "$depth" -lt 20 ]]; do
+    if [[ -f "$directory/Gemfile" ]]; then
+      gemfile="$directory/Gemfile"
       break
     fi
 
-    [[ "$_rbe_dir" == "/" ]] && break
+    [[ "$directory" == "/" ]] && break
 
-    _rbe_parent="${_rbe_dir%/*}"
-    [[ "$_rbe_parent" == "$_rbe_dir" ]] && break
+    parent="${directory%/*}"
+    [[ "$parent" == "$directory" ]] && break
 
-    _rbe_dir="$_rbe_parent"
-    _rbe_depth=$(( _rbe_depth + 1 ))
+    directory="$parent"
+    depth=$((depth + 1))
   done
 fi
 
-if [[ -z "$_rbe_gemfile" ]]; then
-  _rbe_cleanup
-  return 0
-fi
+[[ -z "$gemfile" ]] && return 0
 
-export BUNDLE_GEMFILE="$_rbe_gemfile"
+export BUNDLE_GEMFILE="$gemfile"
 
 [[ -n "${DEBUG_RBENV_BUNDLE_EXEC-}" ]] && echo "bundle exec ${*}" >&2
 
@@ -97,4 +55,5 @@ RBENV_COMMAND="bundle"
 RBENV_COMMAND_PATH="bundle"
 set -- "bundle" "exec" "$@"
 
-_rbe_cleanup
+unset command_name skip_file skipped_command
+unset gemfile directory depth parent

--- a/etc/rbenv.d/exec/bundle-exec.bash
+++ b/etc/rbenv.d/exec/bundle-exec.bash
@@ -1,39 +1,34 @@
-function hasGemfile() {
-  local dir="$PWD"
-  while [ -n "$dir" ]; do
-    if [ -f "$dir/Gemfile" ]; then
-      return 0
+# Skip if already bundling, explicitly disabled, or command is `gem`
+[[ -n "$NO_BUNDLE_EXEC" || "$RBENV_COMMAND" == "bundle" || "$RBENV_COMMAND" == "gem" ]] && return
+
+# Skip if bundler isn't available
+command -v bundle > /dev/null 2>&1 || return
+
+# Skip if command is in ~/.no_bundle_exec
+if [[ -f "$HOME/.no_bundle_exec" ]]; then
+  while IFS= read -r skip_cmd || [[ -n "$skip_cmd" ]]; do
+    [[ "$RBENV_COMMAND" == "$skip_cmd" ]] && return
+  done < "$HOME/.no_bundle_exec"
+fi
+
+# Fast path: Bundler already located a Gemfile (env var set by a parent bundle process)
+if [[ -z "$BUNDLE_GEMFILE" ]]; then
+  # Slow path: walk up the directory tree looking for a Gemfile (max 10 levels)
+  dir="$PWD"
+  depth=0
+  found=0
+  while [[ -n "$dir" && $depth -lt 10 ]]; do
+    if [[ -f "$dir/Gemfile" ]]; then
+      found=1
+      break
     fi
     dir="${dir%/*}"
+    (( depth++ ))
   done
-
-  return 1
-}
-
-function hasBundler() {
-  rbenv-which bundle > /dev/null 2>&1
-}
-
-function commandIgnored() {
-  if [ "$RBENV_COMMAND" = "gem" ]; then return 0; fi
-
-  if [ -f "$HOME/.no_bundle_exec" ]; then
-    for cmd in `cat "$HOME/.no_bundle_exec"`; do
-      if [ "$RBENV_COMMAND" = "$cmd" ]; then
-        return 0
-      fi
-    done
-  fi
-
-  return 1
-}
-
-if [ -z "$NO_BUNDLE_EXEC" -a "$RBENV_COMMAND" != "bundle" ] && hasBundler && hasGemfile && ! commandIgnored; then
-  if [ -n "$DEBUG_RBENV_BUNDLE_EXEC" ]; then
-    echo "bundle exec ${@:1}" >&2
-  fi
-
-  RBENV_COMMAND="bundle"
-  RBENV_COMMAND_PATH="bundle"
-  set -- "bundle" "exec" "${@:1}"
+  [[ $found -eq 0 ]] && return
 fi
+
+[[ -n "$DEBUG_RBENV_BUNDLE_EXEC" ]] && echo "bundle exec ${*}" >&2
+RBENV_COMMAND="bundle"
+RBENV_COMMAND_PATH="bundle"
+set -- "bundle" "exec" "${@}"

--- a/etc/rbenv.d/exec/bundle-exec.bash
+++ b/etc/rbenv.d/exec/bundle-exec.bash
@@ -1,16 +1,35 @@
 # rbenv-bundle-exec
-# rbenv exec hook: run project gem executables through `bundle exec`.
+# rbenv exec hook.
 
+# When a Ruby executable is launched from inside a project with a Gemfile,
+# rewrite the command from:
+#   sidekiq
+# to:
+#   bundle exec sidekiq
+
+# This keeps rbenv/rbenv-gemset from loading executables outside the app's
+# Bundler context.
+
+# rbenv sets RBENV_COMMAND to the shim command being executed.
+# If it is missing, we are not in the expected hook context.
 command_name="${RBENV_COMMAND-}"
 
+# Never wrap Bundler itself, RubyGems, or low-level Ruby commands.
+# Those commands are often used to manage/debug the environment rather than
+# run app dependencies.
 case "$command_name" in
   ""|bundle|gem|ruby|irb|erb|ri|rdoc)
     return 0
     ;;
 esac
 
+# Per-command escape hatch:
+#   NO_BUNDLE_EXEC=1 sidekiq
 [[ -n "${NO_BUNDLE_EXEC-}" ]] && return 0
 
+# Optional persistent skip-list. One command per line.
+#   echo rubocop >> ~/.no_bundle_exec
+# Blank lines and comments are ignored.
 skip_file="${HOME-}/.no_bundle_exec"
 if [[ -n "${HOME-}" && -f "$skip_file" ]]; then
   while IFS= read -r skipped_command || [[ -n "$skipped_command" ]]; do
@@ -21,22 +40,32 @@ if [[ -n "${HOME-}" && -f "$skip_file" ]]; then
   done < "$skip_file"
 fi
 
+# If Bundler is not available, leave the command alone.
+# `command -v` is a shell builtin; no external lookup helper is needed.
 command -v bundle > /dev/null 2>&1 || return 0
 
+# If a parent process already selected a bundle, respect it as long as it still
+# points to a real Gemfile.
 gemfile="${BUNDLE_GEMFILE-}"
+
+# Otherwise, find the nearest Gemfile by walking upward from the current
+# directory. Nearest wins, so nested Ruby projects work correctly.
 if [[ -z "$gemfile" || ! -f "$gemfile" ]]; then
   gemfile=""
   directory="${PWD-}"
   depth=0
 
+  # Bound the search so accidental deep paths never cause excessive work.
   while [[ -n "$directory" && "$depth" -lt 20 ]]; do
     if [[ -f "$directory/Gemfile" ]]; then
       gemfile="$directory/Gemfile"
       break
     fi
 
+    # Stop at filesystem root.
     [[ "$directory" == "/" ]] && break
 
+    # Move one directory up without calling dirname.
     parent="${directory%/*}"
     [[ "$parent" == "$directory" ]] && break
 
@@ -45,15 +74,23 @@ if [[ -z "$gemfile" || ! -f "$gemfile" ]]; then
   done
 fi
 
+# No Gemfile means this is not a Bundler project; leave the command alone.
 [[ -z "$gemfile" ]] && return 0
 
+# Tell Bundler exactly which Gemfile to use. This avoids ambiguity when rbenv,
+# default gems, and gemsets all have overlapping gems installed.
 export BUNDLE_GEMFILE="$gemfile"
 
+# Optional debug output:
+#   DEBUG_RBENV_BUNDLE_EXEC=1 sidekiq
 [[ -n "${DEBUG_RBENV_BUNDLE_EXEC-}" ]] && echo "bundle exec ${*}" >&2
 
+# Rewrite the rbenv command to invoke Bundler, preserving the original command
+# and arguments after `bundle exec`.
 RBENV_COMMAND="bundle"
 RBENV_COMMAND_PATH="bundle"
 set -- "bundle" "exec" "$@"
 
+# Keep later hooks in the same rbenv exec process tidy.
 unset command_name skip_file skipped_command
 unset gemfile directory depth parent

--- a/etc/rbenv.d/exec/bundle-exec.bash
+++ b/etc/rbenv.d/exec/bundle-exec.bash
@@ -1,34 +1,65 @@
-# Skip if already bundling, explicitly disabled, or command is `gem`
-[[ -n "$NO_BUNDLE_EXEC" || "$RBENV_COMMAND" == "bundle" || "$RBENV_COMMAND" == "gem" ]] && return
+# rbenv-bundle-exec
+# Automatically runs ruby gem executables through `bundle exec` inside projects.
 
-# Skip if bundler isn't available
+[[ -n "$NO_BUNDLE_EXEC" ]] && return
+[[ "$RBENV_COMMAND" == "bundle" || "$RBENV_COMMAND" == "gem" ]] && return
+
 command -v bundle > /dev/null 2>&1 || return
 
-# Skip if command is in ~/.no_bundle_exec
 if [[ -f "$HOME/.no_bundle_exec" ]]; then
   while IFS= read -r skip_cmd || [[ -n "$skip_cmd" ]]; do
+    [[ -z "$skip_cmd" || "$skip_cmd" == \#* ]] && continue
     [[ "$RBENV_COMMAND" == "$skip_cmd" ]] && return
   done < "$HOME/.no_bundle_exec"
 fi
 
-# Fast path: Bundler already located a Gemfile (env var set by a parent bundle process)
 if [[ -z "$BUNDLE_GEMFILE" ]]; then
-  # Slow path: walk up the directory tree looking for a Gemfile (max 10 levels)
-  dir="$PWD"
-  depth=0
-  found=0
-  while [[ -n "$dir" && $depth -lt 10 ]]; do
-    if [[ -f "$dir/Gemfile" ]]; then
-      found=1
-      break
+  cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/rbenv-bundle-exec"
+  cache_key="${PWD//\//%2F}"
+  cache_file="$cache_dir/$cache_key"
+
+  if [[ -f "$PWD/Gemfile" ]]; then
+    BUNDLE_GEMFILE="$PWD/Gemfile"
+  elif [[ -f "$cache_file" ]]; then
+    IFS= read -r cached_gemfile < "$cache_file"
+
+    if [[ "$cached_gemfile" == "__none__" ]]; then
+      return
+    elif [[ -f "$cached_gemfile" ]]; then
+      BUNDLE_GEMFILE="$cached_gemfile"
     fi
-    dir="${dir%/*}"
-    (( depth++ ))
-  done
-  [[ $found -eq 0 ]] && return
+  fi
+
+  if [[ -z "$BUNDLE_GEMFILE" ]]; then
+    dir="$PWD"
+    depth=0
+
+    while [[ -n "$dir" && $depth -lt 10 ]]; do
+      if [[ -f "$dir/Gemfile" ]]; then
+        BUNDLE_GEMFILE="$dir/Gemfile"
+        break
+      fi
+
+      [[ "$dir" == "/" ]] && break
+      dir="${dir%/*}"
+      (( depth++ ))
+    done
+
+    mkdir -p "$cache_dir" 2> /dev/null
+
+    if [[ -n "$BUNDLE_GEMFILE" ]]; then
+      printf '%s\n' "$BUNDLE_GEMFILE" > "$cache_file"
+    else
+      printf '%s\n' "__none__" > "$cache_file"
+      return
+    fi
+  fi
+
+  export BUNDLE_GEMFILE
 fi
 
 [[ -n "$DEBUG_RBENV_BUNDLE_EXEC" ]] && echo "bundle exec ${*}" >&2
+
 RBENV_COMMAND="bundle"
 RBENV_COMMAND_PATH="bundle"
 set -- "bundle" "exec" "${@}"


### PR DESCRIPTION
## Summary

Reworked rbenv-bundle-exec into a self-contained rbenv exec hook that automatically routes project Ruby executables through bundle exec when invoked from inside a Bundler project.

## Changes

- Removed dependency on rbenv-which.
- Added defensive command filtering for bundle, gem, ruby, irb, erb, ri, and rdoc.
- Added support for NO_BUNDLE_EXEC=1 as a per-command bypass.
- Added optional persistent skip-list support via ~/.no_bundle_exec.
- Resolves the nearest parent Gemfile with a bounded upward search.
- Preserves a valid existing BUNDLE_GEMFILE when already supplied by a parent process.
- Sets BUNDLE_GEMFILE explicitly before rewriting the command to bundle exec.
- Uses shell builtins only; no cat, dirname, find, pwd, realpath, or helper plugin calls.
- Added comments explaining hook behavior, escape hatches, and Bundler/rbenv interaction.

## Why

This avoids gem activation conflicts when rbenv, rbenv-gemset, default gems, and application-installed gems all expose overlapping versions. Commands launched through rbenv shims from inside a Rails app now run under Bundler automatically, which prevents cases like double-load conflicts.